### PR TITLE
feat: add typography component 

### DIFF
--- a/src/components/atoms/Typography/Typography.tsx
+++ b/src/components/atoms/Typography/Typography.tsx
@@ -1,0 +1,50 @@
+import classnames from 'classnames';
+import React from 'react';
+
+import { TypographyMap } from './bin';
+import type { FontVariant, TypographyElement } from './types';
+
+export interface TextProps
+  extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+  variant?: FontVariant;
+  element?: TypographyElement;
+  href?: string;
+  className?: string;
+  children: React.ReactNode;
+  onClick?: () => void;
+}
+
+export const Typography: React.FC<TextProps> = (props: TextProps) => {
+  const { variant, className = '', href, children, onClick } = props;
+
+  const getElement = () => {
+    if (href) {
+      return 'a';
+    }
+    if (variant) {
+      return TypographyMap[variant].element;
+    }
+    return 'span';
+  };
+
+  const getClassNames = () => {
+    if (variant && variant !== 'none')
+      return TypographyMap[variant]?.className?.toString().replace(/,/g, ' ');
+
+    return '';
+  };
+
+  const TypographyElement = getElement();
+
+  return (
+    <TypographyElement
+      className={classnames(getClassNames(), className)}
+      onClick={onClick}
+      href={href}
+    >
+      {children}
+    </TypographyElement>
+  );
+};
+
+export default Typography;

--- a/src/components/atoms/Typography/bin/TypographyMap.ts
+++ b/src/components/atoms/Typography/bin/TypographyMap.ts
@@ -1,0 +1,55 @@
+import type { FontVariant, TypographyDefinition } from '../types';
+
+export const TypographyMap: Record<FontVariant, TypographyDefinition> = {
+  h1: {
+    element: 'h1',
+    className: ['text-4xl', 'font-sans'],
+  },
+  h2: {
+    element: 'h2',
+    className: ['text-3xl', 'font-sans'],
+  },
+  h3: {
+    element: 'h3',
+    className: ['text-2xl', 'font-sans', 'font-bold'],
+  },
+  h4: {
+    element: 'h4',
+    className: ['text-xl', 'font-sans', 'font-semibold'],
+  },
+  h5: {
+    element: 'h5',
+    className: ['text-lg', 'font-sans', 'font-bold'],
+  },
+  h6: {
+    element: 'h6',
+    className: ['text-base', 'font-sans', 'font-bold'],
+  },
+  normal: {
+    element: 'p',
+    className: ['text-base', 'font-sans'],
+  },
+  eyebrow: {
+    element: 'p',
+    className: ['text-base'],
+  },
+  freelandHeadline: {
+    element: 'h3',
+    className: ['font-freeland', 'text-4xl'],
+  },
+  bullet: {
+    element: 'li',
+    className: ['list-disc'],
+  },
+  number: {
+    element: 'li',
+    className: ['list-decimal'],
+  },
+  none: {
+    element: 'span',
+  },
+  footerLink: {
+    element: 'a',
+    className: ['text-base', 'font-sans'],
+  },
+};

--- a/src/components/atoms/Typography/bin/index.tsx
+++ b/src/components/atoms/Typography/bin/index.tsx
@@ -1,0 +1,1 @@
+export { TypographyMap } from './TypographyMap';

--- a/src/components/atoms/Typography/index.tsx
+++ b/src/components/atoms/Typography/index.tsx
@@ -1,0 +1,1 @@
+export { default as Typography } from './Typography';

--- a/src/components/atoms/Typography/types.ts
+++ b/src/components/atoms/Typography/types.ts
@@ -1,0 +1,33 @@
+export type FontVariant =
+  | 'h1'
+  | 'h2'
+  | 'h3'
+  | 'h4'
+  | 'h5'
+  | 'h6'
+  | 'normal'
+  | 'eyebrow'
+  | 'freelandHeadline'
+  | 'bullet'
+  | 'number'
+  | 'none'
+  | 'footerLink';
+
+export type TypographyDefinition = {
+  element: TypographyElement;
+  fontSize?: string;
+  className?: Array<string | any>;
+};
+
+export type TypographyElement =
+  | 'p'
+  | 'h1'
+  | 'h2'
+  | 'h3'
+  | 'h4'
+  | 'h5'
+  | 'h6'
+  | 'p'
+  | 'span'
+  | 'a'
+  | 'li';

--- a/src/layouts/Meta.tsx
+++ b/src/layouts/Meta.tsx
@@ -35,6 +35,18 @@ const Meta = (props: IMetaProps) => {
           key="icon16"
         />
         <link rel="icon" href="/favicon.ico" key="favicon" />
+
+        {/* Custom fonts */}
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link
+          rel="preconnect"
+          href="https://fonts.gstatic.com"
+          crossOrigin="anonymous"
+        />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Mulish:wght@300;400;700;900&display=swap"
+          rel="stylesheet"
+        />
       </Head>
       <NextSeo
         title={props.title}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,4 +1,6 @@
-@tailwind base;
+@import 'tailwindcss/base';
+@import 'tailwindcss/components';
+@import 'tailwindcss/utilities';
 
 a {
   @apply text-blue-700;
@@ -7,10 +9,6 @@ a {
 a:hover {
   @apply border-b-2 border-blue-700;
 }
-
-@tailwind components;
-
-@tailwind utilities;
 
 .content p {
   @apply my-6;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,12 @@
+const defaultTheme = require('tailwindcss/defaultTheme');
+
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: ['./src/**/*.{js,ts,jsx,tsx}'],
   theme: {
+    fontFamily: {
+      sans: ['Mulish', ...defaultTheme.fontFamily.sans],
+    },
     fontSize: {
       xs: '0.75rem',
       sm: '0.875rem',


### PR DESCRIPTION
**Objective:**
This PR will be add a typography component to unify tags from text.

**Why is important:**
Develop a pattern to html tags (h1, h2, h3, h4, h5, h6, p, and a) for design system.

**Why test this:** 
Import typography component on Design System page, and use a typography with props from "variant" and set a variant as typography; 

Example:
`<Typography variant="h1" classNames="text-red-400" /> `
`<Typography variant="h2" classNames="text-red-400" /> `
`<Typography variant="h3" classNames="text-red-400" /> `
`<Typography variant="normal" classNames="text-red-400" /> `
`<Typography href="https://google.com" /> `
`<Typography onClick={() => console.log("this is my typography with a click event")} /> `